### PR TITLE
Add Subspace namespace

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -483,3 +483,4 @@ holochain-sig-v0,               holochain,      0xa27124,       draft,     Holoc
 holochain-sig-v1,               holochain,      0xa37124,       draft,     Holochain v1 signature  + 8 R-S (63 x Base-32)
 skynet-ns,                      namespace,      0xb19910,       draft,     Skynet Namespace
 arweave-ns,                     namespace,      0xb29910,       draft,     Arweave Namespace
+subspace-ns,                    namespace,      0xb39910,       draft,     Subspace Network Namespace


### PR DESCRIPTION
[Subspace Network](https://subspace.network/) is a blockchain with novel Proof-of-Archival-Storage consensus that is designed to bloat massively.

It has ability to store archival data (and [already does](https://www.parity.io/blog/subspace-archiving-kusama-with-onfinality) on testnet), thus needing a way to address contents in different ways.

This is a request to reserve a namespace similarly to Arweave such that we can use multicodec in future-proof way.